### PR TITLE
Add iOS url scheme suffix feature

### DIFF
--- a/ios/Classes/FBConnect/Facebook.m
+++ b/ios/Classes/FBConnect/Facebook.m
@@ -83,7 +83,7 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
 
 - (id)initWithAppId:(NSString *)appId
         andDelegate:(id<FBSessionDelegate>)delegate {
-    self = [self initWithAppId:appId urlSchemeSuffix:nil andDelegate:delegate];
+    self = [self initWithAppId:appId urlSchemeSuffix:_urlSchemeSuffix andDelegate:delegate];
     return self;
 }
 

--- a/ios/Classes/FBConnect/Facebook.m
+++ b/ios/Classes/FBConnect/Facebook.m
@@ -6,7 +6,7 @@
  * You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
- 
+
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -115,7 +115,7 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
 - (id)initWithAppId:(NSString *)appId
     urlSchemeSuffix:(NSString *)urlSchemeSuffix
         andDelegate:(id<FBSessionDelegate>)delegate {
-    
+
     self = [super init];
     if (self) {
 		appSupportsBackgrounding = ![TiUtils boolValue:@"UIApplicationExitsOnSuspend" properties:[[NSBundle mainBundle] infoDictionary] def:NO];
@@ -123,15 +123,15 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
         _requests = [[NSMutableSet alloc] init];
         _lastAccessTokenUpdate = [[NSDate distantPast] retain];
         _frictionlessRequestSettings = [[FBFrictionlessRequestSettings alloc] init];
-        _tokenCaching = [[FBSessionManualTokenCachingStrategy alloc] init];        
+        _tokenCaching = [[FBSessionManualTokenCachingStrategy alloc] init];
         self.appId = appId;
         self.sessionDelegate = delegate;
         self.urlSchemeSuffix = urlSchemeSuffix;
-        
+
         // observe tokenCaching properties so we can forward KVO
-        [self.tokenCaching addObserver:self 
+        [self.tokenCaching addObserver:self
                             forKeyPath:FBaccessTokenPropertyName
-                               options:NSKeyValueObservingOptionPrior 
+                               options:NSKeyValueObservingOptionPrior
                                context:tokenContext];
         [self.tokenCaching addObserver:self
                             forKeyPath:FBexpirationDatePropertyName
@@ -166,14 +166,14 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
 }
 
 - (void)invalidateSession {
-    
+
     [self.session close];
     [self.tokenCaching clearToken];
-    
+
     [FBSession deleteFacebookCookies];
-    
+
     // setting to nil also terminates any active request for whitelist
-    [_frictionlessRequestSettings updateRecipientCacheWithRecipients:nil]; 
+    [_frictionlessRequestSettings updateRecipientCacheWithRecipients:nil];
 }
 
 #pragma GCC diagnostic push
@@ -193,7 +193,7 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
         [_request removeObserver:self forKeyPath:requestFinishedKeyPath];
         [_requests removeObject:_request];
     }
-    
+
 }
 #pragma GCC diagnostic pop
 
@@ -201,9 +201,9 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
                                     change:(NSDictionary *)change {
     // here we are forwarding KVO notifications from an inner object
     if ([change objectForKey:NSKeyValueChangeNotificationIsPriorKey]) {
-        [self willChangeValueForKey:keyPath];        
-    } else {        
-        [self didChangeValueForKey:keyPath];        
+        [self willChangeValueForKey:keyPath];
+    } else {
+        [self didChangeValueForKey:keyPath];
     }
 }
 
@@ -244,7 +244,7 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
 		NSString *val =
         [[kv objectAtIndex:1]
          stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        
+
 		[params setObject:val forKey:[kv objectAtIndex:0]];
 	}
     return params;
@@ -256,13 +256,13 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
 
         // invalidate current session and create a new one with the same permissions
         NSArray *permissions = self.session.permissions;
-        [self.session close];    
+        [self.session close];
         self.session = [[[FBSession alloc] initWithAppID:_appId
                                              permissions:permissions
                                          urlSchemeSuffix:_urlSchemeSuffix
                                       tokenCacheStrategy:self.tokenCaching]
                            autorelease];
-    
+
         // get the session into a valid state
         [self.session openWithCompletionHandler:nil];
     }
@@ -303,7 +303,7 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
 NSArray * noniOS6Permissions = nil;
 
 - (void)authorize:(NSArray *)permissions {
-    
+
     // if we already have a session, git rid of it
     [self.session close];
     self.session = nil;
@@ -313,7 +313,7 @@ NSArray * noniOS6Permissions = nil;
                                      urlSchemeSuffix:_urlSchemeSuffix
                                   tokenCacheStrategy:self.tokenCaching]
                     autorelease];
-    
+
 	FBSessionLoginBehavior behavior = FBSessionLoginBehaviorWithFallbackToWebView;
 	bool systemFBSDK = [SLComposeViewController class]!=nil;
 	if (forceDialog) {
@@ -340,7 +340,7 @@ NSArray * noniOS6Permissions = nil;
 			}
 		}
 	}
-	
+
     [self.session openWithBehavior:(FBSessionLoginBehavior)behavior
 				 completionHandler:^(FBSession *session, FBSessionState status, NSError *error) {
         switch (status) {
@@ -350,18 +350,18 @@ NSArray * noniOS6Permissions = nil;
                 break;
             case FBSessionStateClosedLoginFailed:
                 { // prefer to keep decls near to their use
-                    
+
                     // unpack the error code and reason in order to compute cancel bool
                     NSString *errorCode = [[error userInfo] objectForKey:FBErrorLoginFailedOriginalErrorCode];
                     NSString *errorReason = [[error userInfo] objectForKey:FBErrorLoginFailedReason];
                     BOOL userDidCancel = !errorCode && (!errorReason ||
                                                         [errorReason isEqualToString:FBErrorLoginFailedReasonInlineCancelledValue]);
-                    
+
                     // call the legacy session delegate
                     [self fbDialogNotLogin:userDidCancel];
                 }
                 break;
-            // presently extension, log-out and invalidation are being implemented in the Facebook class 
+            // presently extension, log-out and invalidation are being implemented in the Facebook class
             default:
                 break; // so we do nothing in response to those state transitions
         }
@@ -369,7 +369,7 @@ NSArray * noniOS6Permissions = nil;
  }
 
 -(NSString*)accessToken {
-    return self.tokenCaching.accessToken;  
+    return self.tokenCaching.accessToken;
 }
 
 -(void)setAccessToken:(NSString *)accessToken {
@@ -428,7 +428,7 @@ NSArray * noniOS6Permissions = nil;
                                                    fromDate:_lastAccessTokenUpdate
                                                      toDate:[NSDate date]
                                                     options:0];
-        
+
         if (components.hour >= kTokenExtendThreshold) {
             return YES;
         }
@@ -468,7 +468,7 @@ NSArray * noniOS6Permissions = nil;
  */
 - (void)logout {
     [self invalidateSession];
-    
+
     if ([self.sessionDelegate respondsToSelector:@selector(fbDidLogout)]) {
         [self.sessionDelegate fbDidLogout];
     }
@@ -512,10 +512,10 @@ NSArray * noniOS6Permissions = nil;
         NSLog(@"API Method must be specified");
         return nil;
     }
-    
+
     NSString * methodName = [params objectForKey:@"method"];
     [params removeObjectForKey:@"method"];
-    
+
     return [self requestWithMethodName:methodName
                              andParams:params
                          andHttpMethod:@"GET"
@@ -578,7 +578,7 @@ NSArray * noniOS6Permissions = nil;
  */
 - (FBRequest*)requestWithGraphPath:(NSString *)graphPath
                        andDelegate:(id <FBRequestDelegate>)delegate {
-    
+
     return [self requestWithGraphPath:graphPath
                             andParams:[NSMutableDictionary dictionary]
                         andHttpMethod:@"GET"
@@ -610,7 +610,7 @@ NSArray * noniOS6Permissions = nil;
 - (FBRequest*)requestWithGraphPath:(NSString *)graphPath
                          andParams:(NSMutableDictionary *)params
                        andDelegate:(id <FBRequestDelegate>)delegate {
-    
+
     return [self requestWithGraphPath:graphPath
                             andParams:params
                         andHttpMethod:@"GET"
@@ -694,14 +694,14 @@ NSArray * noniOS6Permissions = nil;
 - (void)dialog:(NSString *)action
      andParams:(NSMutableDictionary *)params
    andDelegate:(id <FBDialogDelegate>)delegate {
-    
+
     [_fbDialog release];
-    
+
     NSString *dialogURL = [kDialogBaseURL stringByAppendingString:action];
     [params setObject:@"touch" forKey:@"display"];
     [params setObject:kSDKVersion forKey:@"sdk"];
     [params setObject:kRedirectURL forKey:@"redirect_uri"];
-    
+
     if ([action isEqualToString:kLogin]) {
         [params setObject:@"user_agent" forKey:@"type"];
         _fbDialog = [[FBLoginDialog alloc] initWithURL:dialogURL loginParams:params delegate:self];
@@ -712,21 +712,21 @@ NSArray * noniOS6Permissions = nil;
                       forKey:@"access_token"];
             [self extendAccessTokenIfNeeded];
         }
-        
+
         // by default we show dialogs, frictionless cases may have a hidden view
         BOOL invisible = NO;
-        
+
         // frictionless handling for application requests
-        if ([action isEqualToString:kApprequests]) {        
+        if ([action isEqualToString:kApprequests]) {
             // if frictionless requests are enabled
             if (self.isFrictionlessRequestsEnabled) {
                 //  1. show the "Don't show this again for these friends" checkbox
                 //  2. if the developer is sending a targeted request, then skip the loading screen
-                [params setValue:@"1" forKey:@"frictionless"];	
+                [params setValue:@"1" forKey:@"frictionless"];
                 //  3. request the frictionless recipient list encoded in the success url
                 [params setValue:@"1" forKey:@"get_frictionless_recipients"];
             }
-            
+
             // set invisible if all recipients are enabled for frictionless requests
             id fbid = [params objectForKey:@"to"];
             if (fbid != nil) {
@@ -736,18 +736,18 @@ NSArray * noniOS6Permissions = nil;
                 if (![fbids isKindOfClass:[NSArray class]]) {
                     // otherwise seperate by commas (handles the singleton case too)
                     fbids = [fbid componentsSeparatedByString:@","];
-                }                
-                invisible = [self isFrictionlessEnabledForRecipients:fbids];             
+                }
+                invisible = [self isFrictionlessEnabledForRecipients:fbids];
             }
         }
-        
+
         _fbDialog = [[FBDialog alloc] initWithURL:dialogURL
                                            params:params
                                   isViewInvisible:invisible
-                             frictionlessSettings:_frictionlessRequestSettings 
+                             frictionlessSettings:_frictionlessRequestSettings
                                          delegate:delegate];
     }
-    
+
     [_fbDialog show];
 }
 
@@ -777,7 +777,7 @@ NSArray * noniOS6Permissions = nil;
 - (BOOL)isSessionValid {
     return (self.accessToken != nil && self.expirationDate != nil
             && NSOrderedDescending == [self.expirationDate compare:[NSDate date]]);
-    
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -792,7 +792,7 @@ NSArray * noniOS6Permissions = nil;
     [self reloadFrictionlessRecipientCache];
     if ([self.sessionDelegate respondsToSelector:@selector(fbDidLogin)]) {
         [self.sessionDelegate fbDidLogin];
-    }    
+    }
 }
 
 /**
@@ -817,13 +817,13 @@ NSArray * noniOS6Permissions = nil;
     _requestExtendingAccessToken = nil;
     NSString* accessToken = [result objectForKey:@"access_token"];
     NSString* expTime = [result objectForKey:@"expires_at"];
-    
+
     if (accessToken == nil || expTime == nil) {
         return;
     }
-    
+
     self.accessToken = accessToken;
-    
+
     NSTimeInterval timeInterval = [expTime doubleValue];
     NSDate *expirationDate = [NSDate distantFuture];
     if (timeInterval != 0) {
@@ -832,9 +832,9 @@ NSArray * noniOS6Permissions = nil;
     self.expirationDate = expirationDate;
     [_lastAccessTokenUpdate release];
     _lastAccessTokenUpdate = [[NSDate date] retain];
-    
+
     [self updateSessionIfTokenUpdated];
-    
+
     if ([self.sessionDelegate respondsToSelector:@selector(fbDidExtendToken:expiresAt:)]) {
         [self.sessionDelegate fbDidExtendToken:accessToken expiresAt:expirationDate];
     }
@@ -850,7 +850,7 @@ NSArray * noniOS6Permissions = nil;
 }
 
 + (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key {
-    // these properties must manually notify for KVO    
+    // these properties must manually notify for KVO
     if ([key isEqualToString:FBaccessTokenPropertyName] ||
         [key isEqualToString:FBexpirationDatePropertyName]) {
         return NO;

--- a/ios/Classes/FacebookModule.h
+++ b/ios/Classes/FacebookModule.h
@@ -22,6 +22,7 @@
 	NSString *url;
 	NSString *appid;
 	NSArray *permissions;
+	NSString *urlSchemeSuffix;
 	NSMutableArray *stateListeners;
     BOOL forceDialogAuth;
 }

--- a/ios/Classes/FacebookModule.h
+++ b/ios/Classes/FacebookModule.h
@@ -24,7 +24,7 @@
 	NSArray *permissions;
 	NSString *urlSchemeSuffix;
 	NSMutableArray *stateListeners;
-    BOOL forceDialogAuth;
+	BOOL forceDialogAuth;
 }
 
 @property(nonatomic,readonly) Facebook *facebook;

--- a/ios/Classes/FacebookModule.m
+++ b/ios/Classes/FacebookModule.m
@@ -96,6 +96,7 @@
 	appid = [[defaults stringForKey:@"FBAppId"] copy];
 	facebook = [[Facebook alloc] initWithAppId:appid urlSchemeSuffix:nil andDelegate:self];
 	
+	facebook = [[Facebook alloc] initWithAppId:appid urlSchemeSuffix:urlSchemeSuffix andDelegate:self];
 	VerboseLog(@"[DEBUG] facebook _restore, uid = %@",uid_);
 	if (uid_)
 	{
@@ -121,6 +122,7 @@
 	RELEASE_TO_NIL(appid);
 	RELEASE_TO_NIL(permissions);
 	RELEASE_TO_NIL(uid);
+	RELEASE_TO_NIL(urlSchemeSuffix);
 	[super dealloc];
 }
 
@@ -161,6 +163,7 @@
 -(void)startup
 {
 	VerboseLog(@"[DEBUG] facebook startup");
+	[facebook setUrlSchemeSuffix:'myappsuffix'];
 	[super startup];
 	TiThreadPerformOnMainThread(^{
 		NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
@@ -320,6 +323,19 @@ if(![x isKindOfClass:[t class]]){ \
  * JS example:
  *
  * var facebook = require('facebook');
+ * facebook.urlSchemeSuffix = 'myappsuffix';
+ * alert(facebook.urlSchemeSuffix);
+ *
+ */
+-(id)urlSchemeSuffix
+{
+	return urlSchemeSuffix;
+}
+
+/**
+ * JS example:
+ *
+ * var facebook = require('facebook');
  * alert(facebook.forceDialogAuth);
  *
  */
@@ -379,6 +395,21 @@ if(![x isKindOfClass:[t class]]){ \
 {
 	RELEASE_TO_NIL(permissions);
 	permissions = [arg retain];
+}
+
+/**
+ * JS example:
+ *
+ * var facebook = require('facebook');
+ * facebook.urlSchemeSuffix = 'myappsuffix';
+ * alert(facebook.urlSchemeSuffix);
+ *
+ */
+-(void)setUrlSchemeSuffix:(id)arg
+{
+	RELEASE_TO_NIL(urlSchemeSuffix);
+	urlSchemeSuffix = [arg copy];
+	[facebook setUrlSchemeSuffix:urlSchemeSuffix];
 }
 
 /**

--- a/ios/Classes/FacebookModule.m
+++ b/ios/Classes/FacebookModule.m
@@ -50,27 +50,27 @@
 	} else {
 		[defaults removeObjectForKey:@"FBUserId"];
 	}
-	
+
 	NSString *access_token = facebook.accessToken;
 	if ((access_token != (NSString *) [NSNull null]) && (access_token.length > 0)) {
 		[defaults setObject:access_token forKey:@"FBAccessToken"];
 	} else {
 		[defaults removeObjectForKey:@"FBAccessToken"];
 	}
-	
+
 	NSDate *expirationDate = facebook.expirationDate;
 	if (expirationDate) {
 		[defaults setObject:expirationDate forKey:@"FBSessionExpires"];
 	} else {
 		[defaults removeObjectForKey:@"FBSessionExpires"];
 	}
-	
+
 	if (appid) {
 		[defaults setObject:appid forKey:@"FBAppId"];
 	}else {
 		[defaults removeObjectForKey:@"FBAppId"];
 	}
-	
+
 	[defaults synchronize];
 }
 
@@ -94,9 +94,8 @@
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	NSString *uid_ = [defaults objectForKey:@"FBUserId"];
 	appid = [[defaults stringForKey:@"FBAppId"] copy];
-	facebook = [[Facebook alloc] initWithAppId:appid urlSchemeSuffix:nil andDelegate:self];
-	
 	facebook = [[Facebook alloc] initWithAppId:appid urlSchemeSuffix:urlSchemeSuffix andDelegate:self];
+
 	VerboseLog(@"[DEBUG] facebook _restore, uid = %@",uid_);
 	if (uid_)
 	{
@@ -151,7 +150,7 @@
 -(void)resumed:(id)note
 {
 	VerboseLog(@"[DEBUG] facebook resumed");
-	
+
 	[self handleRelaunch];
 }
 
@@ -177,7 +176,7 @@
 -(void)shutdown:(id)sender
 {
 	VerboseLog(@"[DEBUG] facebook shutdown");
-	
+
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	[super shutdown:sender];
 }
@@ -195,7 +194,7 @@
 	for (NSString *key in [params allKeys])
 	{
 		id param = [params objectForKey:key];
-		
+
 		// convert to blob
 		if ([param isKindOfClass:[TiFile class]])
 		{
@@ -210,7 +209,7 @@
 				param = [[[TiBlob alloc] initWithData:[NSData data] mimetype:@"text/plain"] autorelease];
 			}
 		}
-		
+
 		// this is an attachment, we need to convert to POST and switch to blob
 		if ([param isKindOfClass:[TiBlob class]])
 		{
@@ -341,7 +340,7 @@ if(![x isKindOfClass:[t class]]){ \
  */
 -(id)forceDialogAuth
 {
-    return [NSNumber numberWithBool:forceDialogAuth];
+	return [NSNumber numberWithBool:forceDialogAuth];
 }
 
 /**
@@ -422,7 +421,7 @@ if(![x isKindOfClass:[t class]]){ \
  */
 -(void)setForceDialogAuth:(id)arg
 {
-    forceDialogAuth = [TiUtils boolValue:arg def:NO];
+	forceDialogAuth = [TiUtils boolValue:arg def:NO];
 }
 
 /**
@@ -454,22 +453,22 @@ if(![x isKindOfClass:[t class]]){ \
 -(void)authorize:(id)args
 {
 	VerboseLog(@"[DEBUG] facebook authorize");
-	
+
 	if ([self isLoggedIn])
 	{
 		// if already authorized, this should do nothing
 		return;
 	}
-	
+
 	if (appid==nil)
 	{
 		[self throwException:@"missing appid" subreason:nil location:CODELOCATION];
 	}
-	
+
 	TiThreadPerformOnMainThread(^{
 		// forget in case it fails
 		[self _unsave];
-		
+
 		NSArray *permissions_ = permissions == nil ? [NSArray array] : permissions;
 		[facebook setForceDialog:forceDialogAuth];
 		[facebook authorize:permissions_];
@@ -493,24 +492,24 @@ if(![x isKindOfClass:[t class]]){ \
 -(void)reauthorize:(id)args
 {
 	ENSURE_ARG_COUNT(args, 3);
-	
+
 	if (![self isLoggedIn])
 	{
 		[self throwException:@"NotAuthorized" subreason:@"App tried to reauthorize before being logged in." location:CODELOCATION];
 		return;
 	}
-	
+
 	NSArray * writePermissions = [args objectAtIndex:0];
 	NSString * audienceString = [TiUtils stringValue:[args objectAtIndex:1]];
 	KrollCallback * callback = [args objectAtIndex:2];
-	
+
 	FACEBOOK_ENSURE_TYPE(writePermissions, NSArray, @"an array");
 	FACEBOOK_ENSURE_TYPE(audienceString, NSString, @"a string");
 	FACEBOOK_ENSURE_TYPE(callback, KrollCallback, @"a function");
-	
+
 	FBSessionLoginBehavior behavior = FBSessionLoginBehaviorUseSystemAccountIfPresent;
 	FBSessionDefaultAudience audience = FBSessionDefaultAudienceEveryone;
-	
+
 	FBSessionReauthorizeResultHandler handler= ^(FBSession *session, NSError *error)
 	{
 		bool success = (error == nil);
@@ -534,18 +533,18 @@ if(![x isKindOfClass:[t class]]){ \
 				errorString = [errorString stringByAppendingFormat:@" %@",userInfoMessage];
 			}
 		}
-		
+
 		NSNumber * errorCode = [NSNumber numberWithInteger:code];
 		NSDictionary * propertiesDict = [[NSDictionary alloc] initWithObjectsAndKeys:
 										 [NSNumber numberWithBool:success],@"success",
 										 errorCode,@"code", errorString,@"error", nil];
-		
+
 		KrollEvent * invocationEvent = [[KrollEvent alloc] initWithCallback:callback eventObject:propertiesDict thisObject:self];
 		[[callback context] enqueue:invocationEvent];
 		[invocationEvent release];
 		[propertiesDict release];
 	};
-	
+
 	TiThreadPerformOnMainThread(^{
 		[[facebook session] reauthorizeWithPublishPermissions:writePermissions
 											  defaultAudience:audience
@@ -587,21 +586,21 @@ if(![x isKindOfClass:[t class]]){ \
 -(void)requestWithGraphPath:(id)args
 {
 	VerboseLog(@"[DEBUG] facebook requestWithGraphPath");
-	
+
 	ENSURE_ARG_COUNT(args,4);
-	
+
 	NSString* path = [args objectAtIndex:0];
 	NSMutableDictionary* params = [args objectAtIndex:1];
 	NSString* httpMethod = [args objectAtIndex:2];
 	KrollCallback* callback = [args objectAtIndex:3];
-	
+
 	FACEBOOK_ENSURE_TYPE(path, NSString, @"a string");
 	FACEBOOK_ENSURE_TYPE(params, NSDictionary, @"an object");
 	FACEBOOK_ENSURE_TYPE(httpMethod, NSString, @"a string");
 	FACEBOOK_ENSURE_TYPE(callback, KrollCallback, @"a function");
-	
+
 	[self convertParams:params];
-	
+
 	TiThreadPerformOnMainThread(^{
 		TiFacebookRequest* delegate = [[[TiFacebookRequest alloc] initWithPath:path callback:callback module:self graph:YES] autorelease];
 		[facebook requestWithGraphPath:path andParams:params andHttpMethod:httpMethod andDelegate:delegate];
@@ -626,9 +625,9 @@ if(![x isKindOfClass:[t class]]){ \
 -(void)request:(id)args
 {
 	VerboseLog(@"[DEBUG] facebook request");
-	
+
 	ENSURE_ARG_COUNT(args,3);
-	
+
 	NSString* method = [args objectAtIndex:0];
 	NSMutableDictionary* params = [args objectAtIndex:1];
 	KrollCallback* callback = [args objectAtIndex:2];
@@ -642,7 +641,7 @@ if(![x isKindOfClass:[t class]]){ \
 	if (changedHttpMethod != nil) {
 		httpMethod = changedHttpMethod;
 	}
-	
+
 	TiThreadPerformOnMainThread(^{
 		TiFacebookRequest* delegate = [[[TiFacebookRequest alloc] initWithPath:method callback:callback module:self graph:NO] autorelease];
 		[facebook requestWithMethodName:method andParams:params andHttpMethod:httpMethod andDelegate:delegate];
@@ -663,19 +662,19 @@ if(![x isKindOfClass:[t class]]){ \
 -(void)dialog:(id)args
 {
 	ENSURE_ARG_COUNT(args,3);
-	
+
 	VerboseLog(@"[DEBUG] facebook dialog");
-	
+
 	NSString* action = [args objectAtIndex:0];
 	NSMutableDictionary* params = [args objectAtIndex:1];
 	KrollCallback* callback = [args objectAtIndex:2];
-	
+
 	FACEBOOK_ENSURE_TYPE(action, NSString, @"a string");
 	FACEBOOK_ENSURE_TYPE(params, NSDictionary, @"an object");
 	FACEBOOK_ENSURE_TYPE(callback, KrollCallback, @"a function");
-	
+
 	[self convertParams:params];
-	
+
 	TiThreadPerformOnMainThread(^{
 		TiFacebookDialogRequest *delegate = [[[TiFacebookDialogRequest alloc] initWithCallback:callback module:self] autorelease];
 		[facebook dialog:action andParams:params andDelegate:delegate];
@@ -738,7 +737,7 @@ if(![x isKindOfClass:[t class]]){ \
 		{
 			errorString = [errorString stringByAppendingFormat:@" %@",userInfoMessage];
 		}
-		
+
 		if (errorString != nil) {
 			[event setObject:errorString forKey:@"error"];
 		}
@@ -768,7 +767,7 @@ if(![x isKindOfClass:[t class]]){ \
 - (void)fbDidLogin
 {
 	VerboseLog(@"[DEBUG] facebook fbDidLogin");
-	
+
 	[facebook requestWithGraphPath:@"me" andDelegate:self];
 }
 
@@ -789,7 +788,7 @@ if(![x isKindOfClass:[t class]]){ \
 - (void)fbDidLogout
 {
 	VerboseLog(@"[DEBUG] facebook fbDidLogout");
-	
+
 	loggedIn = NO;
 	[self _unsave];
 	[self fireLoginChange];
@@ -825,7 +824,7 @@ if(![x isKindOfClass:[t class]]){ \
 - (void)request:(FBRequest*)request didLoad:(id)result
 {
 	VerboseLog(@"[DEBUG] facebook didLoad");
-	
+
 	RELEASE_TO_NIL(uid);
 	uid = [[result objectForKey:@"id"] copy];
 	[self _save];
@@ -838,7 +837,7 @@ if(![x isKindOfClass:[t class]]){ \
 - (void)request:(FBRequest*)request didFailWithError:(NSError*)error
 {
 	VerboseLog(@"[DEBUG] facebook didFailWithError: %@",error);
-	
+
 	RELEASE_TO_NIL(uid);
 	loggedIn = NO;
 	[self fireLoginChange];


### PR DESCRIPTION
This is a feature we use a lot to have severals iOS apps using the same Facebook App.

You can find the Facebook documentation here : https://developers.facebook.com/docs/howtos/share-appid-across-multiple-apps-ios-sdk/

I posted a Q&A on this topic : http://developer.appcelerator.com/question/137857/how-to-define-a-specific-facebook-url-scheme-suffix-for-my-ios-app
I also posted a JIRA : https://jira.appcelerator.org/browse/TIMOB-9701

This JIRA is almost 1 year-old and still opened, we patched your module to make it works on our apps. It would be great to integrate this patch to the main code.
